### PR TITLE
Add specific error handling for old versions

### DIFF
--- a/lib/Apache/Session/Store/LDAP.pm
+++ b/lib/Apache/Session/Store/LDAP.pm
@@ -138,8 +138,22 @@ sub ldap {
         ),
     ) or die( 'Unable to connect to ' . join( ' ', @servers ) . ': ' . $@ );
 
-    # Start TLS if needed
+    # Check SSL error for old Net::LDAP versions
+    if ( $Net::LDAP::VERSION < '0.64' ) {
 
+        # CentOS7 has a bug in which IO::Socket::SSL will return a broken
+        # socket when certificate validation fails. Net::LDAP does not catch
+        # it, and the process ends up crashing.
+        # As a precaution, make sure the underlying socket is doing fine:
+        if (    $ldap->socket->isa('IO::Socket::SSL')
+            and $ldap->socket->errstr < 0 )
+        {
+            $self->logError( "SSL connection error: " . $ldap->socket->errstr );
+            return;
+        }
+    }
+
+    # Start TLS if needed
     if ($useTls) {
         my %h = split( /[&=]/, $tlsParam );
         $h{verify} ||= ( $self->{args}->{ldapVerify} || "require" );

--- a/lib/Apache/Session/Store/LDAP.pm
+++ b/lib/Apache/Session/Store/LDAP.pm
@@ -148,8 +148,7 @@ sub ldap {
         if (    $ldap->socket->isa('IO::Socket::SSL')
             and $ldap->socket->errstr < 0 )
         {
-            $self->logError( "SSL connection error: " . $ldap->socket->errstr );
-            return;
+            die( "SSL connection error: " . $ldap->socket->errstr );
         }
     }
 


### PR DESCRIPTION
Use code from @maxbes to better handle SSL errors for CentOS 7